### PR TITLE
Multi stack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,11 @@
 module github.com/rs/zerolog
+
+go 1.12
+
+require (
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/pkg/errors v0.8.1
+	github.com/rs/xid v1.2.1
+	github.com/zenazn/goji v0.9.0
+	golang.org/x/tools v0.0.0-20190321154406-ae772f11d294
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/zenazn/goji v0.9.0 h1:RSQQAbXGArQ0dIDEq+PI6WqN6if+5KHu6x2Cx/GXLTQ=
+github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190321154406-ae772f11d294 h1:gMPF/7U3xs3RNmp7bh9BoJnRg81e5uKSYpyaGoAmadw=
+golang.org/x/tools v0.0.0-20190321154406-ae772f11d294/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/pkgerrors/stacktrace.go
+++ b/pkgerrors/stacktrace.go
@@ -1,8 +1,6 @@
 package pkgerrors
 
 import (
-	"encoding/json"
-
 	"github.com/pkg/errors"
 )
 
@@ -67,10 +65,6 @@ func MarshalStack(err error) interface{} {
 	return out
 }
 
-type multiStack struct {
-	StackTraces []stackTrace
-}
-
 type stackTrace struct {
 	Frames []frame `json:"stacktrace"`
 }
@@ -85,7 +79,7 @@ type frame struct {
 //
 //   zerolog.ErrorStackMarshaler = MarshalMultiStack
 func MarshalMultiStack(err error) interface{} {
-	multiStack := multiStack{}
+	stackTraces := []stackTrace{}
 	currentErr := err
 	for currentErr != nil {
 		stack, ok := currentErr.(stackTracer)
@@ -106,15 +100,11 @@ func MarshalMultiStack(err error) interface{} {
 			}
 			stackTrace.Frames = append(stackTrace.Frames, frame)
 		}
-		multiStack.StackTraces = append(multiStack.StackTraces, stackTrace)
+		stackTraces = append(stackTraces, stackTrace)
 
 		currentErr = unwrapErr(currentErr)
 	}
-	marshalled, err := json.Marshal(multiStack.StackTraces)
-	if err != nil {
-		return ""
-	}
-	return string(marshalled)
+	return stackTraces
 }
 
 type causer interface {

--- a/pkgerrors/stacktrace_test.go
+++ b/pkgerrors/stacktrace_test.go
@@ -37,7 +37,7 @@ func TestLogMultiStack(t *testing.T) {
 	log.Log().Stack().Err(err).Msg("")
 
 	got := out.String()
-	want := `\{"stack":"\[\{\"stacktrace\":\[\{\"source\":\"stacktrace_test.go\",\"line\":\"36\",\"func\":\"TestLogMultiStack\"\},.*\{\"stacktrace\".*\],"error":"from error: error message"\}`
+	want := `\{"stack":\[\{"stacktrace":\[\{"source":"stacktrace_test.go","line":"36","func":"TestLogMultiStack"\},.*\{"stacktrace".*\],"error":"from error: error message"\}`
 	if ok, _ := regexp.MatchString(want, got); !ok {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
@@ -45,9 +45,8 @@ func TestLogMultiStack(t *testing.T) {
 }
 
 // Some methods of wrapping cause more layers of wrapping than other layers,
-// e.g. errors.New doesn't cause any wrapping, errors.WithStack and
-// errors.WithMessage add one layer of wrapping, whereas errors.Wrap adds
-// two layers of wrapping.
+// e.g. errors.New, errors.WithStack and errors.WithMessage add one layer of
+// wrapping, whereas errors.Wrap adds two layers of wrapping.
 func TestUnwrapErr(t *testing.T) {
 	table := []struct {
 		name               string
@@ -55,45 +54,40 @@ func TestUnwrapErr(t *testing.T) {
 		numberOfWrapLevels int
 	}{
 		{
-			name:               "pass in nil error",
-			err:                nil,
-			numberOfWrapLevels: 0,
-		},
-		{
 			name:               "fundamental error",
 			err:                errors.New("error message"),
-			numberOfWrapLevels: 0,
+			numberOfWrapLevels: 1,
 		},
 		{
 			name:               "singly wrapped error",
 			err:                errors.Wrap(errors.New("error message"), "from error"),
-			numberOfWrapLevels: 2,
+			numberOfWrapLevels: 3,
 		},
 		{
 			name:               "doubly wrapped error",
 			err:                errors.Wrap(errors.Wrap(errors.New("error message"), "first wrapper"), "second wrapper"),
-			numberOfWrapLevels: 4,
+			numberOfWrapLevels: 5,
 		},
 		{
 			name:               "wrap with WithStack",
 			err:                errors.WithStack(errors.New("error message")),
-			numberOfWrapLevels: 1,
+			numberOfWrapLevels: 2,
 		},
 		{
 			name:               "wrap with WithMessage",
 			err:                errors.WithMessage(errors.New("error message"), "first wrapper"),
-			numberOfWrapLevels: 1,
+			numberOfWrapLevels: 2,
 		},
 		{
 			name:               "wrap with WithMessage and Wrap",
 			err:                errors.Wrap(errors.WithMessage(errors.New("error message"), "first wrapper"), "second wrapper"),
-			numberOfWrapLevels: 3,
+			numberOfWrapLevels: 4,
 		},
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
 			currentErr := test.err
-			for i := 0; i <= test.numberOfWrapLevels; i++ {
+			for i := 0; i < test.numberOfWrapLevels; i++ {
 				currentErr = unwrapErr(currentErr)
 			}
 			if currentErr != nil {


### PR DESCRIPTION
There is an issue with the way the MarshalStack is implemented right now. It only prints info on the last stack trace -- which is really unhelpful if you have multiple stacks (i.e. you really want to know where the original stack trace came from).

This pull request adds the ability to log all of the stack traces collected by the errors.